### PR TITLE
Add ASE constraints support for selective dynamics

### DIFF
--- a/docs/source/howto/calculations.md
+++ b/docs/source/howto/calculations.md
@@ -1,3 +1,201 @@
 # Calculations
 
-This page is under construction and will be available soon. 🙂
+This page provides guidance on setting up and running ABACUS calculations with AiiDA.
+
+## Using ASE Constraints for Selective Dynamics
+
+AiiDA-ABACUS supports ASE constraints for controlling which atoms can move during geometry optimization. Constraints are automatically converted to ABACUS's selective dynamics format (the `m` keyword in the STRU file).
+
+### Quick Start
+
+```python
+from ase.build import bulk
+from ase.constraints import FixAtoms
+from aiida.orm import StructureData
+
+# Create structure with constraints
+atoms = bulk("Si", "diamond", a=5.43).repeat((2, 2, 2))
+atoms.set_constraint(FixAtoms(indices=[0, 1, 2, 3]))  # Fix first 4 atoms
+
+# Use with builder - constraints are automatically handled
+builder.structure = StructureData(ase=atoms)
+builder.dynamics = atoms  # This converts constraints to ABACUS format
+```
+
+### Supported Constraint Types
+
+#### FixAtoms
+
+Fixes all three directions (x, y, z) for specified atoms:
+
+```python
+from ase.constraints import FixAtoms
+
+# Fix atoms by index
+atoms.set_constraint(FixAtoms(indices=[0, 1, 2]))
+```
+
+**Use case:** Surface slabs where you want to fix the bottom layers that represent the bulk substrate.
+
+#### FixScaled
+
+Fixes specific fractional (direct) coordinate directions:
+
+```python
+from ase.constraints import FixScaled
+
+# Fix x and z directions, allow y
+atoms.set_constraint(FixScaled(
+    indices=[5, 6],
+    mask=(True, False, True)  # True = fixed, False = movable
+))
+```
+
+**Important:** ASE uses `True=fixed`, but ABACUS uses `1=movable`. The conversion is automatic.
+
+**Use case:** Constraining motion along specific crystallographic directions, such as fixing the z-coordinate for surface atoms while allowing xy relaxation.
+
+#### FixCartesian
+
+Fixes specific Cartesian directions (only for orthogonal cells):
+
+```python
+from ase.constraints import FixCartesian
+
+# Fix x and y directions, allow z (requires orthogonal cell)
+atoms.set_constraint(FixCartesian(
+    indices=[3, 4],
+    mask=(True, True, False)
+))
+```
+
+**Warning:** ABACUS selective dynamics operates in fractional coordinates. `FixCartesian` only works correctly when cell vectors are aligned with Cartesian axes. For non-orthogonal cells, use `FixScaled` instead.
+
+**Use case:** When working with orthogonal cells and you need to constrain movement in Cartesian x, y, or z directions.
+
+### Multiple Constraints
+
+You can combine multiple constraints - restrictions are accumulated (union):
+
+```python
+from ase.constraints import FixAtoms, FixScaled
+
+constraint1 = FixAtoms(indices=[0, 1])  # Fix atoms 0, 1 completely
+constraint2 = FixScaled([2, 3], mask=(False, False, True))  # Fix z for atoms 2, 3
+
+atoms.set_constraint([constraint1, constraint2])
+```
+
+### Three Ways to Specify Selective Dynamics
+
+There are three methods to control which atoms can move (in priority order):
+
+#### 1. ASE Atoms via dynamics port (NEW, recommended)
+
+```python
+from ase.build import bulk
+from ase.constraints import FixAtoms
+
+atoms = bulk("Si").repeat((2, 2, 2))
+atoms.set_constraint(FixAtoms(indices=[0, 1]))
+builder.dynamics = atoms  # Automatic conversion
+```
+
+**Advantages:**
+- Most intuitive and Pythonic
+- Leverages ASE's well-documented constraint system
+- Type-safe with proper validation
+- Automatic mask convention inversion
+
+#### 2. Manual dynamics Dict (NEW, explicit control)
+
+```python
+builder.dynamics = orm.Dict({
+    "m": [
+        [True, True, True],    # Atom 0: fully movable
+        [False, False, False], # Atom 1: fully fixed
+        [True, True, False],   # Atom 2: xy movable, z fixed
+    ]
+})
+```
+
+**Advantages:**
+- Explicit control over each degree of freedom
+- No dependency on ASE
+- Direct mapping to ABACUS format
+
+#### 3. Legacy parameters approach (EXISTING, backwards compatible)
+
+```python
+builder.parameters = orm.Dict({
+    "input": {...},
+    "stru": {
+        "m": [[True, True, True], [False, False, False], ...]
+    }
+})
+```
+
+**Priority resolution:**
+- If `builder.dynamics` is provided → uses it (highest priority)
+- Else if `parameters["stru"]["m"]` exists → uses it (legacy fallback)
+- Else → defaults to all atoms movable (ABACUS default)
+
+**Important:** An error will be raised if you specify the `m` flags in both `builder.dynamics` and `parameters["stru"]["m"]` to avoid ambiguity. Use only one method.
+
+This ensures zero breaking changes while providing a superior user experience.
+
+### ABACUS Format Details
+
+Internally, constraints are converted to ABACUS STRU file format:
+- `True` (movable) → `1` in STRU file
+- `False` (fixed) → `0` in STRU file
+
+Example STRU file content:
+```
+Si
+0.0
+2
+0.00 0.00 0.00 m 0 0 0    # Fixed atom (cannot move)
+0.25 0.25 0.25 m 1 1 1    # Movable atom (can move in all directions)
+```
+
+### Troubleshooting
+
+**Issue:** `FixCartesian` raises error about non-orthogonal cell
+
+**Solution:** Use `FixScaled` instead, which works with fractional coordinates:
+```python
+# Instead of FixCartesian
+atoms.set_constraint(FixScaled(indices=[...], mask=(True, False, True)))
+```
+
+**Issue:** Constraints not being applied
+
+**Solution:** Make sure you're passing ASE Atoms to `builder.dynamics`.
+
+
+**Issue:** Error about specifying 'm' flags in both dynamics and parameters
+
+**Solution:** You cannot specify selective dynamics in both places. 
+
+**Issue:** How to check if constraints were converted correctly?
+
+**Solution:** Use the `serialize_dynamics` function to verify:
+```python
+from aiida_abacus.utils import serialize_dynamics
+
+dynamics_dict = serialize_dynamics(atoms)
+print(dynamics_dict.get_dict())
+# Shows: {"m": [[True, True, True], [False, False, False], ...]}
+```
+
+### Related Documentation
+
+- **ABACUS STRU format**: https://abacus.deepmodeling.com/en/latest/advanced/input_files/stru.html
+- **ASE constraints**: https://wiki.fysik.dtu.dk/ase/ase/constraints.html
+
+### API Reference
+
+For detailed API documentation, see:
+- `aiida_abacus.utils.atoms_to_move_list()` - Convert ASE constraints to move_list
+- `aiida_abacus.utils.serialize_dynamics()` - Serialize for builder.dynamics port

--- a/docs/source/howto/calculations.md
+++ b/docs/source/howto/calculations.md
@@ -172,8 +172,91 @@ print(dynamics_dict.get_dict())
 - **ABACUS STRU format**: https://abacus.deepmodeling.com/en/latest/advanced/input_files/stru.html
 - **ASE constraints**: https://wiki.fysik.dtu.dk/ase/ase/constraints.html
 
-### API Reference
+## Setting Initial Velocities for Molecular Dynamics
 
-For detailed API documentation, see:
-- `aiida_abacus.utils.atoms_to_move_list()` - Convert ASE constraints to move_list
-- `aiida_abacus.utils.serialize_dynamics()` - Serialize for builder.dynamics port
+aiida-abacus supports setting initial atomic velocities for molecular dynamics simulations.
+
+### Quick Start
+
+```python
+from aiida import orm
+
+# Create velocity list (one 3D vector per atom)
+velocities = [
+    [0.1, 0.0, 0.0],   # Atom 0: velocity in x direction
+    [0.0, 0.1, 0.0],   # Atom 1: velocity in y direction
+    [-0.1, 0.0, 0.1],  # Atom 2: mixed velocities
+]
+
+# Set via dynamics port (recommended)
+builder.dynamics = orm.Dict({"v": velocities})
+
+# Or combine with selective dynamics
+builder.dynamics = orm.Dict({
+    "m": [[True, True, True]] * 3,  # Move flags
+    "v": velocities                  # Initial velocities
+})
+```
+
+### Units and Conversion
+
+**Atomic Units:** ABACUS uses atomic units for velocities
+
+## Magnetic Moments (magmom)
+
+ABACUS supports setting initial magnetic moments for magnetic calculations. This feature is already implemented in aiida-abacus.
+
+### Quick Start
+
+```python
+# Set magnetic moments (one 3D vector per atom)
+# For collinear calculations, only one number should be given
+# For non-collinear, use [m_x, m_y, m_z]
+colinear_magnetic_moments = [
+    [1.0],   # Atom 0: spin up
+    [-1.0],  # Atom 1: spin down
+]
+none_colinear_magnetic_moments = [
+    [0.0, 0.0, 1.0],   # Atom 0: spin up in z
+    [0.0, 0.0, -1.0],  # Atom 1: spin down in z
+]
+
+builder.parameters = orm.Dict({
+    "input": {"nspin": 2, ...},
+    "stru": {
+        "mag": collinear_magnetic_moments  # or "magmom"
+    }
+})
+```
+
+### Alias Support
+
+Two aliases are supported: `mag` and `magmom`
+
+```python
+# These are equivalent
+parameters["stru"]["mag"] = magnetic_moments
+# Or use "magmom" is also OK
+parameters["stru"].pop("mag", None)
+parameters["stru"]["magmom"] = magnetic_moments
+```
+
+### STRU Format
+
+Magnetic moments are written after position and velocity:
+
+None-colinear case:
+```
+0.00 0.00 0.00 m 1 1 1 v 0.1 0.0 0.0 magmom 0.0 0.0 1.0
+```
+
+colinear case:
+```
+0.00 0.00 0.00 m 1 1 1 v 0.1 0.0 0.0 magmom 1.0
+```
+
+### Integration with nspin
+
+- `nspin = 1`: No spin polarization (magmom ignored)
+- `nspin = 2`: Collinear spin
+- `nspin = 4`: None-collinear spin, `noncolin=1` also needs to be set.

--- a/docs/source/howto/calculations.md
+++ b/docs/source/howto/calculations.md
@@ -24,6 +24,8 @@ builder.dynamics = atoms  # This converts constraints to ABACUS format
 
 ### Supported Constraint Types
 
+AiiDA-ABACUS supports two ASE constraint types. ABACUS selective dynamics operates in Cartesian directions.
+
 #### FixAtoms
 
 Fixes all three directions (x, y, z) for specified atoms:
@@ -37,51 +39,35 @@ atoms.set_constraint(FixAtoms(indices=[0, 1, 2]))
 
 **Use case:** Surface slabs where you want to fix the bottom layers that represent the bulk substrate.
 
-#### FixScaled
+#### FixCartesian
 
-Fixes specific fractional (direct) coordinate directions:
+Fixes specific Cartesian directions:
 
 ```python
-from ase.constraints import FixScaled
+from ase.constraints import FixCartesian
 
-# Fix x and z directions, allow y
-atoms.set_constraint(FixScaled(
-    indices=[5, 6],
-    mask=(True, False, True)  # True = fixed, False = movable
+# Fix x and y directions, allow z
+atoms.set_constraint(FixCartesian(
+    indices=[3, 4],
+    mask=(True, True, False)  # True = fixed, False = movable
 ))
 ```
 
 **Important:** ASE uses `True=fixed`, but ABACUS uses `1=movable`. The conversion is automatic.
 
-**Use case:** Constraining motion along specific crystallographic directions, such as fixing the z-coordinate for surface atoms while allowing xy relaxation.
+**Use case:** Constraining motion along specific Cartesian directions, such as fixing the z-coordinate for surface atoms while allowing xy relaxation.
 
-#### FixCartesian
-
-Fixes specific Cartesian directions (only for orthogonal cells):
-
-```python
-from ase.constraints import FixCartesian
-
-# Fix x and y directions, allow z (requires orthogonal cell)
-atoms.set_constraint(FixCartesian(
-    indices=[3, 4],
-    mask=(True, True, False)
-))
-```
-
-**Warning:** ABACUS selective dynamics operates in fractional coordinates. `FixCartesian` only works correctly when cell vectors are aligned with Cartesian axes. For non-orthogonal cells, use `FixScaled` instead.
-
-**Use case:** When working with orthogonal cells and you need to constrain movement in Cartesian x, y, or z directions.
+**Note:** FixScaled is NOT supported - ABACUS selective dynamics uses Cartesian directions. Use FixCartesian instead.
 
 ### Multiple Constraints
 
 You can combine multiple constraints - restrictions are accumulated (union):
 
 ```python
-from ase.constraints import FixAtoms, FixScaled
+from ase.constraints import FixAtoms, FixCartesian
 
 constraint1 = FixAtoms(indices=[0, 1])  # Fix atoms 0, 1 completely
-constraint2 = FixScaled([2, 3], mask=(False, False, True))  # Fix z for atoms 2, 3
+constraint2 = FixCartesian([2, 3], mask=(False, False, True))  # Fix z for atoms 2, 3
 
 atoms.set_constraint([constraint1, constraint2])
 ```
@@ -161,14 +147,6 @@ Si
 
 ### Troubleshooting
 
-**Issue:** `FixCartesian` raises error about non-orthogonal cell
-
-**Solution:** Use `FixScaled` instead, which works with fractional coordinates:
-```python
-# Instead of FixCartesian
-atoms.set_constraint(FixScaled(indices=[...], mask=(True, False, True)))
-```
-
 **Issue:** Constraints not being applied
 
 **Solution:** Make sure you're passing ASE Atoms to `builder.dynamics`.
@@ -176,7 +154,7 @@ atoms.set_constraint(FixScaled(indices=[...], mask=(True, False, True)))
 
 **Issue:** Error about specifying 'm' flags in both dynamics and parameters
 
-**Solution:** You cannot specify selective dynamics in both places. 
+**Solution:** You cannot specify selective dynamics in both places. Choose one method: either `builder.dynamics` (recommended) or `parameters["stru"]["m"]` (legacy).
 
 **Issue:** How to check if constraints were converted correctly?
 

--- a/src/aiida_abacus/calculations.py
+++ b/src/aiida_abacus/calculations.py
@@ -11,6 +11,7 @@ from aiida import orm
 from aiida.common import datastructures, exceptions
 from aiida.common.utils import get_unique_filename
 from aiida.engine import CalcJob
+from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import DataFactory
 from aiida_pseudo.data.pseudo.upf import UpfData
 
@@ -18,6 +19,7 @@ from aiida_abacus.common.opthold import SettingsOptions
 from aiida_abacus.data.orbital import AtomicOrbitalData
 
 from .common import make_retrieve_list
+from .utils import serialize_dynamics
 
 LegacyUpfData = DataFactory("core.upf")
 
@@ -75,11 +77,11 @@ class AbacusCalculation(CalcJob):
         # "input" dict will be written into INPUT file after validation
         # "stru" dict will be queried to write STRU file
         # thus, parameters is likely some Dict() of {"input": {}, "stru": {}}
-        spec.input("parameters", valid_type=orm.Dict, help="The ABACUS input parameters.")
+        spec.input("parameters", serializer=to_aiida_type, valid_type=orm.Dict, help="The ABACUS input parameters.")
 
         # kpoints, which is a KpointsData
         # will be written into KPT file after validation
-        spec.input("kpoints", valid_type=orm.KpointsData, help="The kpoints KPT.")
+        spec.input("kpoints", serializer=to_aiida_type, valid_type=orm.KpointsData, help="The kpoints KPT.")
 
         # structure, which is a StructureData
         # and some other parameters (Dict)
@@ -99,7 +101,20 @@ class AbacusCalculation(CalcJob):
             help=SettingsOptions.aiida_description(),
             required=False,
         )
-        # spec.input("dynamics", valid_type=orm.Dict, help="The dynamics parameters in STRU.")
+
+        # Dynamics port for ASE constraints and selective dynamics
+        spec.input(
+            "dynamics",
+            valid_type=orm.Dict,
+            serializer=serialize_dynamics,
+            help=(
+                "ABACUS parameters related to ionic dynamics. "
+                "Can be set directly from ASE Atoms with constraints: "
+                "builder.dynamics = atoms. Supports FixAtoms, FixScaled, and FixCartesian. "
+                "Contains the 'm' key for selective dynamics flags (move/fix atoms)."
+            ),
+            required=False,
+        )
         # spec.input("magmom", valid_type=orm.Dict, help="The magnetic moments in STRU.")
 
         # dynamic pseudopotential input port namespace, adapted from aiida-castep
@@ -319,9 +334,12 @@ class AbacusCalculation(CalcJob):
         """Generate the content of input file STRU according to structure.
         For detailed documentation,
         see the ABACUS documentation about the `STRU file <https://abacus.deepmodeling.com/en/latest/advanced/input_files/stru.html>`_.
+
         :param structure: a StructureData object
         :param pseudos: a dictionary of pseudopotential nodes
-        :param parameters: a dictionary of stru parameters
+        :param parameters: a dictionary of stru parameters. The 'm' key for move flags
+            will be taken from the dynamics input port if provided, otherwise from this
+            parameters dict.
         :return: the content of the input file STRU & a list of pseudopotential files to be copied"""
         # may add some validation here, and maybe some conversions
 
@@ -474,9 +492,29 @@ class AbacusCalculation(CalcJob):
         # that is even though no 'm' KEYWORD is given, this set of params still need to be given
         # KEYWORD m: the atom is allowed to move in geometry relaxation calculations
         # like [[True, True, True]]
-        move_list = parameters.get("m")  # default value for move_x, move_y, move_z
+        # Priority: dynamics port > parameters["m"] > default all movable
+
+        # Check both sources for "m" key
+        dynamics_m = None
+        parameters_m = parameters.get("m")
+
+        if hasattr(self, "inputs") and "dynamics" in self.inputs:
+            dynamics_dict = self.inputs.dynamics.get_dict()
+            dynamics_m = dynamics_dict.get("m")
+
+        # Raise error if both sources provide "m" to avoid ambiguity
+        if dynamics_m is not None and parameters_m is not None:
+            raise exceptions.InputValidationError(
+                "Selective dynamics ('m' flags) specified in both 'dynamics' port and "
+                "parameters['stru']['m']. Please use only one method. "
+                "Recommended: use 'builder.dynamics' with ASE Atoms constraints."
+            )
+
+        # Use priority: dynamics > parameters > default
+        move_list = dynamics_m if dynamics_m is not None else parameters_m
+
+        # Default to all atoms movable if neither provided
         if move_list is None:
-            # Default to move the atoms
             move_list = [[True, True, True]] * len(coordinates)
 
         ### BELOW are optional keywords!!!###

--- a/src/aiida_abacus/calculations.py
+++ b/src/aiida_abacus/calculations.py
@@ -110,8 +110,9 @@ class AbacusCalculation(CalcJob):
             help=(
                 "ABACUS parameters related to ionic dynamics. "
                 "Can be set directly from ASE Atoms with constraints: "
-                "builder.dynamics = atoms. Supports FixAtoms, FixScaled, and FixCartesian. "
-                "Contains the 'm' key for selective dynamics flags (move/fix atoms)."
+                "builder.dynamics = atoms. Supports FixAtoms and FixCartesian. "
+                "Contains the 'm' key for selective dynamics flags (move/fix atoms), "
+                "and 'v' key for initial velocities (molecular dynamics)."
             ),
             required=False,
         )
@@ -518,10 +519,78 @@ class AbacusCalculation(CalcJob):
             move_list = [[True, True, True]] * len(coordinates)
 
         ### BELOW are optional keywords!!!###
+        # KEYWORD v/vel/velocity: set initial velocities for each atom
+        # Units: atomic units (1 a.u. = 21.877 Angstrom/fs)
+        velocity_list = None
+        dynamics_v = None
+        parameters_v = None
+
+        # Check parameters for velocity aliases - raise error if multiple
+        velocity_aliases = ["v", "vel", "velocity"]
+        params_velocity_keys = [alias for alias in velocity_aliases if parameters.get(alias) is not None]
+        if len(params_velocity_keys) > 1:
+            raise exceptions.InputValidationError(
+                f"Multiple velocity aliases found in parameters['stru']: {params_velocity_keys}. "
+                "Please use only one: 'v', 'vel', or 'velocity'."
+            )
+        if params_velocity_keys:
+            parameters_v = parameters.get(params_velocity_keys[0])
+
+        # Check dynamics port for velocity aliases - raise error if multiple
+        if hasattr(self, "inputs") and "dynamics" in self.inputs:
+            dynamics_dict = self.inputs.dynamics.get_dict()
+            dynamics_velocity_keys = [alias for alias in velocity_aliases if dynamics_dict.get(alias) is not None]
+            if len(dynamics_velocity_keys) > 1:
+                raise exceptions.InputValidationError(
+                    f"Multiple velocity aliases found in dynamics port: {dynamics_velocity_keys}. "
+                    "Please use only one: 'v', 'vel', or 'velocity'."
+                )
+            if dynamics_velocity_keys:
+                dynamics_v = dynamics_dict.get(dynamics_velocity_keys[0])
+
+        # Raise error if both sources provide velocity
+        if dynamics_v is not None and parameters_v is not None:
+            raise exceptions.InputValidationError(
+                "Initial velocities specified in both 'dynamics' port and parameters['stru']. "
+                "Please use only one method. Recommended: use 'builder.dynamics' with Dict."
+            )
+
+        # Use velocity from dynamics or parameters
+        velocity_list = dynamics_v if dynamics_v is not None else parameters_v
+
+        # Validate velocity_list if provided
+        if velocity_list is not None:
+            if len(velocity_list) != len(coordinates):
+                raise exceptions.InputValidationError(
+                    f"Velocity list length ({len(velocity_list)}) does not match "
+                    f"number of atoms ({len(coordinates)})"
+                )
+            # Validate each velocity has 3 components
+            for i, vel in enumerate(velocity_list):
+                if not isinstance(vel, (list, tuple)) or len(vel) != 3:
+                    raise exceptions.InputValidationError(
+                        f"Velocity for atom {i} must be a list/tuple of 3 numbers, got: {vel}"
+                    )
+                # Validate numeric values
+                try:
+                    [float(v) for v in vel]
+                except (TypeError, ValueError) as e:
+                    raise exceptions.InputValidationError(
+                        f"Velocity for atom {i} contains non-numeric values: {vel}"
+                    ) from e
+
         # KEYWORD mag or magmom: set the start magnetization for each atom
         # set three number for the xyz commponent of magnetization here (e.g. mag 0.0 0.0 1.0).
 
-        magmom_list = parameters.get("mag") or parameters.get("magmom", [])  # default value for mag_x, mag_y, mag_z
+        # Check for multiple magmom aliases
+        magmom_aliases = ["mag", "magmom"]
+        magmom_keys = [alias for alias in magmom_aliases if parameters.get(alias) is not None]
+        if len(magmom_keys) > 1:
+            raise exceptions.InputValidationError(
+                f"Multiple magmom aliases found in parameters['stru']: {magmom_keys}. "
+                "Please use only one: 'mag' or 'magmom'."
+            )
+        magmom_list = parameters.get(magmom_keys[0], []) if magmom_keys else []
 
         # Add and count atoms.
         # The following three lines tells the elemental type (Fe),
@@ -534,6 +603,11 @@ class AbacusCalculation(CalcJob):
             # Add the move flags
             flags = map(int, move_list[i])  # Ensure int type
             position.extend(["m", *flags])  # Set the move flag for geometry optimization
+
+            # Add velocity if provided
+            if velocity_list is not None:
+                vel_float = map(float, velocity_list[i])  # Ensure float type
+                position.extend(["v", *vel_float])  # Set initial velocity for molecular dynamics
 
             # each position is a line containing the following information:
             # In colinear case only one number should be given.

--- a/src/aiida_abacus/utils.py
+++ b/src/aiida_abacus/utils.py
@@ -1,13 +1,12 @@
 """
 Utilities for converting ASE constraints to ABACUS "m" key in STRU file.
 
-This module provides functions to convert ASE constraint objects (FixAtoms, FixScaled, FixCartesian)
+This module provides functions to convert ASE constraint objects (FixAtoms, FixCartesian)
 into ABACUS's "m" key in the STRU file.
 """
 
 from __future__ import annotations
 
-import warnings
 from typing import Union
 
 import numpy as np
@@ -18,36 +17,11 @@ from ase import Atoms
 from ase.constraints import FixAtoms, FixCartesian, FixScaled
 
 
-def _is_cell_orthogonal(cell: np.ndarray, tol: float = 1e-6) -> bool:
-    """
-    Check if cell vectors are aligned with Cartesian x, y, z axes.
-
-    :param cell: Cell vectors as (3, 3) array
-    :type cell: np.ndarray
-    :param tol: Tolerance for considering off-diagonal elements as zero
-    :type tol: float
-    :returns: True if cell is orthogonal (aligned with Cartesian axes)
-    :rtype: bool
-    """
-    # Check if cell is diagonal (off-diagonal elements should be ~0)
-    # Cell format: [[a_x, a_y, a_z], [b_x, b_y, b_z], [c_x, c_y, c_z]]
-    # For orthogonal: a_y, a_z, b_x, b_z, c_x, c_y should be ~0
-    off_diagonal = [
-        cell[0, 1],
-        cell[0, 2],  # a_y, a_z
-        cell[1, 0],
-        cell[1, 2],  # b_x, b_z
-        cell[2, 0],
-        cell[2, 1],  # c_x, c_y
-    ]
-    return all(abs(val) < tol for val in off_diagonal)
-
-
 def atoms_to_move_list(atoms: Atoms) -> np.ndarray | None:
     """
     Convert ASE constraints to ABACUS move_list format.
 
-    This function extracts FixAtoms, FixScaled, and FixCartesian constraints from an ASE Atoms object
+    This function extracts FixAtoms and FixCartesian constraints from an ASE Atoms object
     and converts them to ABACUS's selective dynamics format (the "m" keyword in STRU file).
     Multiple constraints are properly accumulated using a union of restrictions.
 
@@ -57,18 +31,14 @@ def atoms_to_move_list(atoms: Atoms) -> np.ndarray | None:
         can move in that direction (ABACUS convention: True→1, False→0), False means fixed.
         Returns None if no constraints are present.
     :rtype: np.ndarray | None
-    :raises InputValidationError: If an unsupported constraint type is encountered or if
-        FixCartesian is used with non-orthogonal cells
+    :raises InputValidationError: If an unsupported constraint type is encountered (e.g., FixScaled)
 
     .. note::
-        - Supports FixAtoms (fixes all 3 directions), FixScaled (fixes specific
-          fractional directions), and FixCartesian (fixes Cartesian directions).
+        - Supports FixAtoms (fixes all 3 directions) and FixCartesian (fixes Cartesian directions).
         - ASE mask convention (True=fixed) is automatically inverted to ABACUS
           convention (True=movable, converted to 1 in STRU file).
-        - ABACUS selective dynamics operates in fractional (direct) coordinates.
-        - FixCartesian only works correctly when cell vectors are aligned with
-          Cartesian axes. A warning is issued if used, and an error is raised if
-          the cell is not orthogonal.
+        - ABACUS selective dynamics operates in Cartesian directions.
+        - FixScaled is NOT supported - use FixCartesian instead.
         - Multiple constraints on the same atom are accumulated (union of restrictions).
 
     Example::
@@ -99,44 +69,22 @@ def atoms_to_move_list(atoms: Atoms) -> np.ndarray | None:
             move_list[indices, :] = False
 
         elif isinstance(constraint, FixScaled):
-            # FixScaled: fix specific fractional directions
-            # CRITICAL: ASE mask convention is opposite to ABACUS
-            # ASE: True = fixed, False = movable
-            # ABACUS: True = movable, False = fixed (converted to 1/0 in STRU file)
+            # FixScaled is NOT supported - ABACUS selective dynamics uses Cartesian directions
+            raise InputValidationError(
+                "FixScaled constraint is not supported for ABACUS calculations. "
+                "ABACUS selective dynamics operates in Cartesian directions. "
+                "Please use FixCartesian instead to constrain specific Cartesian directions."
+            )
+
+        elif isinstance(constraint, FixCartesian):
+            # FixCartesian: fix specific Cartesian directions
+            # ABACUS selective dynamics operates in Cartesian directions
+            # ASE mask convention: True = fixed, False = movable
+            # ABACUS convention: True = movable, False = fixed (converted to 1/0 in STRU file)
             indices = constraint.get_indices()
             mask = constraint.mask  # ASE convention: True = fixed
 
             # Invert mask: where ASE mask is True (fixed), set ABACUS move flag to False (fixed)
-            move_list[indices, mask] = False
-
-        elif isinstance(constraint, FixCartesian):
-            # FixCartesian: fix specific Cartesian directions
-            # WARNING: ABACUS selective dynamics works in fractional coordinates!
-            # This only works correctly if cell vectors are aligned with Cartesian axes
-
-            # Check if cell is orthogonal
-            cell = atoms.get_cell()
-            if not _is_cell_orthogonal(cell):
-                raise InputValidationError(
-                    "FixCartesian constraint cannot be used with non-orthogonal cells. "
-                    "ABACUS selective dynamics operates in fractional coordinates. "
-                    "For non-orthogonal cells, use FixScaled instead or ensure your "
-                    "cell vectors are aligned with x, y, z axes."
-                )
-
-            # Issue warning about fractional vs Cartesian
-            warnings.warn(
-                "FixCartesian constraint is being converted to ABACUS selective dynamics. "
-                "Note that ABACUS selective dynamics operates in fractional (direct) coordinates. "
-                "This conversion assumes your cell vectors are aligned with Cartesian x, y, z axes. "
-                "Consider using FixScaled for explicit fractional coordinate control.",
-                UserWarning,
-                stacklevel=2,
-            )
-
-            # Treat like FixScaled with same logic
-            indices = constraint.get_indices()
-            mask = constraint.mask  # ASE convention: True = fixed
             move_list[indices, mask] = False
 
         else:
@@ -144,7 +92,7 @@ def atoms_to_move_list(atoms: Atoms) -> np.ndarray | None:
             constraint_type = type(constraint).__name__
             raise InputValidationError(
                 f"Unsupported constraint type '{constraint_type}'. "
-                f"Only FixAtoms, FixScaled, and FixCartesian are supported for ABACUS selective dynamics. "
+                f"Only FixAtoms and FixCartesian are supported for ABACUS selective dynamics. "
                 f"For complex constraints, manually specify the 'dynamics' port with a move_list array."
             )
 
@@ -166,9 +114,9 @@ def serialize_dynamics(atoms: Union[Atoms, dict]) -> orm.Dict | None:
     :rtype: orm.Dict | None
 
     .. note::
-        Handles FixAtoms, FixScaled, and FixCartesian constraints. Multiple constraints
-        are properly accumulated (union of restrictions). FixCartesian requires
-        orthogonal cells.
+        Handles FixAtoms and FixCartesian constraints. Multiple constraints
+        are properly accumulated (union of restrictions). FixScaled is NOT
+        supported - use FixCartesian instead.
 
         The output format is: ``{"m": [[bool, bool, bool], ...]}`` where True means
         movable (converted to 1 in STRU file) and False means fixed (converted to 0),

--- a/src/aiida_abacus/utils.py
+++ b/src/aiida_abacus/utils.py
@@ -1,0 +1,200 @@
+"""
+Utilities for converting ASE constraints to ABACUS "m" key in STRU file.
+
+This module provides functions to convert ASE constraint objects (FixAtoms, FixScaled, FixCartesian)
+into ABACUS's "m" key in the STRU file.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Union
+
+import numpy as np
+from aiida import orm
+from aiida.common.exceptions import InputValidationError
+from aiida.orm.nodes.data.base import to_aiida_type
+from ase import Atoms
+from ase.constraints import FixAtoms, FixCartesian, FixScaled
+
+
+def _is_cell_orthogonal(cell: np.ndarray, tol: float = 1e-6) -> bool:
+    """
+    Check if cell vectors are aligned with Cartesian x, y, z axes.
+
+    :param cell: Cell vectors as (3, 3) array
+    :type cell: np.ndarray
+    :param tol: Tolerance for considering off-diagonal elements as zero
+    :type tol: float
+    :returns: True if cell is orthogonal (aligned with Cartesian axes)
+    :rtype: bool
+    """
+    # Check if cell is diagonal (off-diagonal elements should be ~0)
+    # Cell format: [[a_x, a_y, a_z], [b_x, b_y, b_z], [c_x, c_y, c_z]]
+    # For orthogonal: a_y, a_z, b_x, b_z, c_x, c_y should be ~0
+    off_diagonal = [
+        cell[0, 1],
+        cell[0, 2],  # a_y, a_z
+        cell[1, 0],
+        cell[1, 2],  # b_x, b_z
+        cell[2, 0],
+        cell[2, 1],  # c_x, c_y
+    ]
+    return all(abs(val) < tol for val in off_diagonal)
+
+
+def atoms_to_move_list(atoms: Atoms) -> np.ndarray | None:
+    """
+    Convert ASE constraints to ABACUS move_list format.
+
+    This function extracts FixAtoms, FixScaled, and FixCartesian constraints from an ASE Atoms object
+    and converts them to ABACUS's selective dynamics format (the "m" keyword in STRU file).
+    Multiple constraints are properly accumulated using a union of restrictions.
+
+    :param atoms: ASE Atoms object with optional constraints
+    :type atoms: Atoms
+    :returns: Numpy array of shape (N, 3) with dtype=bool, where True means the atom
+        can move in that direction (ABACUS convention: True→1, False→0), False means fixed.
+        Returns None if no constraints are present.
+    :rtype: np.ndarray | None
+    :raises InputValidationError: If an unsupported constraint type is encountered or if
+        FixCartesian is used with non-orthogonal cells
+
+    .. note::
+        - Supports FixAtoms (fixes all 3 directions), FixScaled (fixes specific
+          fractional directions), and FixCartesian (fixes Cartesian directions).
+        - ASE mask convention (True=fixed) is automatically inverted to ABACUS
+          convention (True=movable, converted to 1 in STRU file).
+        - ABACUS selective dynamics operates in fractional (direct) coordinates.
+        - FixCartesian only works correctly when cell vectors are aligned with
+          Cartesian axes. A warning is issued if used, and an error is raised if
+          the cell is not orthogonal.
+        - Multiple constraints on the same atom are accumulated (union of restrictions).
+
+    Example::
+
+        >>> from ase import Atoms
+        >>> from ase.constraints import FixAtoms
+        >>> atoms = Atoms('H2O', positions=[[0,0,0], [1,0,0], [0,1,0]])
+        >>> atoms.set_constraint(FixAtoms(indices=[0]))
+        >>> dof = atoms_to_move_list(atoms)
+        >>> dof[0]  # First atom fixed
+        array([False, False, False])
+        >>> dof[1]  # Second atom free
+        array([True, True, True])
+    """
+    # Return None if no constraints
+    if not atoms.constraints:
+        return None
+
+    # Initialize all atoms as movable (True = movable in ABACUS, converted to 1 in STRU)
+    natoms = len(atoms)
+    move_list = np.ones((natoms, 3), dtype=bool)
+
+    # Process each constraint
+    for constraint in atoms.constraints:
+        if isinstance(constraint, FixAtoms):
+            # FixAtoms: fix all 3 directions for specified atoms
+            indices = constraint.get_indices()
+            move_list[indices, :] = False
+
+        elif isinstance(constraint, FixScaled):
+            # FixScaled: fix specific fractional directions
+            # CRITICAL: ASE mask convention is opposite to ABACUS
+            # ASE: True = fixed, False = movable
+            # ABACUS: True = movable, False = fixed (converted to 1/0 in STRU file)
+            indices = constraint.get_indices()
+            mask = constraint.mask  # ASE convention: True = fixed
+
+            # Invert mask: where ASE mask is True (fixed), set ABACUS move flag to False (fixed)
+            move_list[indices, mask] = False
+
+        elif isinstance(constraint, FixCartesian):
+            # FixCartesian: fix specific Cartesian directions
+            # WARNING: ABACUS selective dynamics works in fractional coordinates!
+            # This only works correctly if cell vectors are aligned with Cartesian axes
+
+            # Check if cell is orthogonal
+            cell = atoms.get_cell()
+            if not _is_cell_orthogonal(cell):
+                raise InputValidationError(
+                    "FixCartesian constraint cannot be used with non-orthogonal cells. "
+                    "ABACUS selective dynamics operates in fractional coordinates. "
+                    "For non-orthogonal cells, use FixScaled instead or ensure your "
+                    "cell vectors are aligned with x, y, z axes."
+                )
+
+            # Issue warning about fractional vs Cartesian
+            warnings.warn(
+                "FixCartesian constraint is being converted to ABACUS selective dynamics. "
+                "Note that ABACUS selective dynamics operates in fractional (direct) coordinates. "
+                "This conversion assumes your cell vectors are aligned with Cartesian x, y, z axes. "
+                "Consider using FixScaled for explicit fractional coordinate control.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+            # Treat like FixScaled with same logic
+            indices = constraint.get_indices()
+            mask = constraint.mask  # ASE convention: True = fixed
+            move_list[indices, mask] = False
+
+        else:
+            # Unsupported constraint type
+            constraint_type = type(constraint).__name__
+            raise InputValidationError(
+                f"Unsupported constraint type '{constraint_type}'. "
+                f"Only FixAtoms, FixScaled, and FixCartesian are supported for ABACUS selective dynamics. "
+                f"For complex constraints, manually specify the 'dynamics' port with a move_list array."
+            )
+
+    return move_list
+
+
+def serialize_dynamics(atoms: Union[Atoms, dict]) -> orm.Dict | None:
+    """
+    Serialize ASE Atoms with constraints to dynamics Dict for builder.dynamics port.
+
+    This is a convenience function that converts ASE constraints to an AiiDA Dict
+    node ready for direct use with the builder.dynamics port. The output Dict
+    contains the "m" key corresponding to ABACUS STRU file's move flags.
+
+    :param atoms: ASE Atoms object with optional constraints, or dict to pass through
+    :type atoms: Union[Atoms, dict]
+    :returns: orm.Dict with "m" key containing move flags, or None if no constraints.
+        The Dict is ready for direct assignment: ``builder.dynamics = serialize_dynamics(atoms)``
+    :rtype: orm.Dict | None
+
+    .. note::
+        Handles FixAtoms, FixScaled, and FixCartesian constraints. Multiple constraints
+        are properly accumulated (union of restrictions). FixCartesian requires
+        orthogonal cells.
+
+        The output format is: ``{"m": [[bool, bool, bool], ...]}`` where True means
+        movable (converted to 1 in STRU file) and False means fixed (converted to 0),
+        matching ABACUS's convention.
+
+    Example::
+
+        >>> from ase.build import bulk
+        >>> from ase.constraints import FixAtoms
+        >>> from aiida_abacus.utils import serialize_dynamics
+        >>>
+        >>> atoms = bulk("Si", "diamond", a=5.43).repeat((2, 2, 2))
+        >>> atoms.set_constraint(FixAtoms(indices=[0, 1, 2, 3]))
+        >>>
+        >>> # Direct usage with builder
+        >>> builder.dynamics = serialize_dynamics(atoms)
+    """
+    if not isinstance(atoms, Atoms):
+        return to_aiida_type(atoms)
+
+    # Get move_list array
+    move_list = atoms_to_move_list(atoms)
+
+    # Return None if no constraints
+    if move_list is None:
+        return None
+
+    # Convert to Dict node (tolist() converts numpy array to JSON-serializable list)
+    return orm.Dict(dict={"m": move_list.tolist()})

--- a/src/aiida_abacus/utils.py
+++ b/src/aiida_abacus/utils.py
@@ -122,6 +122,9 @@ def serialize_dynamics(atoms: Union[Atoms, dict]) -> orm.Dict | None:
         movable (converted to 1 in STRU file) and False means fixed (converted to 0),
         matching ABACUS's convention.
 
+        Additionally supports velocity through dict input: ``{"m": [...], "v": [...]}``
+        where the "v" key contains velocity vectors in atomic units (1 a.u. = 21.877 Å/fs).
+
     Example::
 
         >>> from ase.build import bulk
@@ -133,6 +136,17 @@ def serialize_dynamics(atoms: Union[Atoms, dict]) -> orm.Dict | None:
         >>>
         >>> # Direct usage with builder
         >>> builder.dynamics = serialize_dynamics(atoms)
+
+    Example with velocity::
+
+        >>> from aiida_abacus.utils import serialize_dynamics
+        >>> from aiida import orm
+        >>>
+        >>> # With velocities for molecular dynamics
+        >>> builder.dynamics = serialize_dynamics({
+        ...     "m": [[True, True, True]] * 4,
+        ...     "v": [[0.1, 0.0, 0.0]] * 4  # velocities in a.u.
+        ... })
     """
     if not isinstance(atoms, Atoms):
         return to_aiida_type(atoms)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -35,10 +35,19 @@ def test_no_constraints_returns_none():
     assert atoms_to_move_list(atoms) is None
 
 
-# FixScaled tests
-def test_fixscaled_basic(h3_atoms):
-    """Test FixScaled with partial constraints."""
+# FixScaled tests - should raise error
+def test_fixscaled_raises_error(h3_atoms):
+    """Test that FixScaled constraint raises an error."""
     h3_atoms.set_constraint(FixScaled([1], mask=(True, False, True)))
+
+    with pytest.raises(InputValidationError, match="FixScaled constraint is not supported"):
+        atoms_to_move_list(h3_atoms)
+
+
+# FixCartesian tests
+def test_fixcartesian_basic(h3_atoms):
+    """Test FixCartesian with partial constraints."""
+    h3_atoms.set_constraint(FixCartesian([1], mask=(True, False, True)))
 
     move_list = atoms_to_move_list(h3_atoms)
 
@@ -47,36 +56,15 @@ def test_fixscaled_basic(h3_atoms):
     np.testing.assert_array_equal(move_list[2], [True, True, True])
 
 
-def test_fixscaled_mask_inversion():
+def test_fixcartesian_mask_inversion():
     """Test ASE mask convention (True=fixed) inverts to ABACUS (True=movable)."""
     atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
-    atoms.set_constraint(FixScaled([1], mask=(True, True, False)))
+    atoms.set_constraint(FixCartesian([1], mask=(True, True, False)))
 
     move_list = atoms_to_move_list(atoms)
 
     # ASE mask (True, True, False) = fix x,y → ABACUS (False, False, True)
     np.testing.assert_array_equal(move_list[1], [False, False, True])
-
-
-# FixCartesian tests
-def test_fixcartesian_orthogonal():
-    """Test FixCartesian with orthogonal cell issues warning."""
-    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
-    atoms.set_constraint(FixCartesian([1], mask=(True, False, True)))
-
-    with pytest.warns(UserWarning, match="FixCartesian"):
-        move_list = atoms_to_move_list(atoms)
-
-    np.testing.assert_array_equal(move_list[1], [False, True, False])
-
-
-def test_fixcartesian_nonorthogonal_raises():
-    """Test FixCartesian with non-orthogonal cell raises error."""
-    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[[5, 0, 0], [1, 5, 0], [0, 0, 5]])
-    atoms.set_constraint(FixCartesian([0], mask=(True, False, False)))
-
-    with pytest.raises(InputValidationError, match="non-orthogonal"):
-        atoms_to_move_list(atoms)
 
 
 # Multiple constraints
@@ -93,10 +81,10 @@ def test_multiple_fixatoms():
     assert not np.any(move_list[3])  # Fixed
 
 
-def test_mixed_fixatoms_and_fixscaled():
-    """Test FixAtoms + FixScaled combine correctly."""
+def test_mixed_fixatoms_and_fixcartesian():
+    """Test FixAtoms + FixCartesian combine correctly."""
     atoms = Atoms("H4", positions=[[i, 0, 0] for i in range(4)], cell=[5, 5, 5])
-    atoms.set_constraint([FixAtoms(indices=[0]), FixScaled([1], mask=(False, True, False))])
+    atoms.set_constraint([FixAtoms(indices=[0]), FixCartesian([1], mask=(False, True, False))])
 
     move_list = atoms_to_move_list(atoms)
 
@@ -105,13 +93,13 @@ def test_mixed_fixatoms_and_fixscaled():
     np.testing.assert_array_equal(move_list[2], [True, True, True])
 
 
-def test_overlapping_constraints():
-    """Test overlapping constraints use union of restrictions."""
+def test_overlapping_fixcartesian_constraints():
+    """Test overlapping FixCartesian constraints use union of restrictions."""
     atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
     atoms.set_constraint(
         [
-            FixScaled([1], mask=(True, False, False)),  # Fix x
-            FixScaled([1], mask=(False, True, False)),  # Fix y
+            FixCartesian([1], mask=(True, False, False)),  # Fix x
+            FixCartesian([1], mask=(False, True, False)),  # Fix y
         ]
     )
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -187,3 +187,43 @@ def test_boolean_to_abacus_format():
 
     expected = np.array([[1, 1, 1], [0, 0, 0], [1, 1, 1]])
     np.testing.assert_array_equal(abacus_flags, expected)
+
+
+# ==============================================================================
+# Velocity Tests
+# ==============================================================================
+
+
+def test_velocity_in_dynamics_dict(aiida_profile_clean):
+    """Test velocity can be specified in dynamics Dict."""
+    velocities = [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [-0.1, 0.0, 0.0]]
+
+    dynamics_dict = {"v": velocities}
+    result = serialize_dynamics(dynamics_dict)
+
+    assert isinstance(result, orm.Dict)
+    assert result.get_dict()["v"] == velocities
+
+
+def test_velocity_with_move_flags(aiida_profile_clean):
+    """Test velocity and move flags can be combined."""
+    dynamics_dict = {
+        "m": [[True, True, True], [False, False, False], [True, True, True]],
+        "v": [[0.1, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.1, 0.0]],
+    }
+
+    result = serialize_dynamics(dynamics_dict)
+
+    assert isinstance(result, orm.Dict)
+    assert result.get_dict()["m"] == dynamics_dict["m"]
+    assert result.get_dict()["v"] == dynamics_dict["v"]
+
+
+def test_velocity_aliases(aiida_profile_clean):
+    """Test all velocity aliases are supported."""
+    velocities = [[0.1, 0.0, 0.0]]
+
+    for alias in ["v", "vel", "velocity"]:
+        dynamics_dict = {alias: velocities}
+        result = serialize_dynamics(dynamics_dict)
+        assert result.get_dict()[alias] == velocities

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,201 @@
+"""Tests for ASE constraints to ABACUS move flags conversion."""
+
+import numpy as np
+import pytest
+from aiida import orm
+from aiida.common.exceptions import InputValidationError
+from aiida_abacus.utils import atoms_to_move_list, serialize_dynamics
+from ase import Atoms
+from ase.constraints import FixAtoms, FixBondLength, FixCartesian, FixScaled
+
+
+# Fixtures
+@pytest.fixture
+def h3_atoms():
+    """Three hydrogen atoms in a line."""
+    return Atoms("H3", positions=[[i, 0, 0] for i in range(3)], cell=[5, 5, 5])
+
+
+# FixAtoms tests
+def test_fixatoms_basic():
+    """Test FixAtoms fixes all 3 directions."""
+    atoms = Atoms("H3", positions=[[i, 0, 0] for i in range(3)])
+    atoms.set_constraint(FixAtoms(indices=[0, 2]))
+
+    move_list = atoms_to_move_list(atoms)
+
+    assert not np.any(move_list[0])  # Atom 0 fixed
+    assert np.all(move_list[1])  # Atom 1 free
+    assert not np.any(move_list[2])  # Atom 2 fixed
+
+
+def test_no_constraints_returns_none():
+    """Test that atoms without constraints return None."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]])
+    assert atoms_to_move_list(atoms) is None
+
+
+# FixScaled tests
+def test_fixscaled_basic(h3_atoms):
+    """Test FixScaled with partial constraints."""
+    h3_atoms.set_constraint(FixScaled([1], mask=(True, False, True)))
+
+    move_list = atoms_to_move_list(h3_atoms)
+
+    np.testing.assert_array_equal(move_list[0], [True, True, True])
+    np.testing.assert_array_equal(move_list[1], [False, True, False])  # x,z fixed
+    np.testing.assert_array_equal(move_list[2], [True, True, True])
+
+
+def test_fixscaled_mask_inversion():
+    """Test ASE mask convention (True=fixed) inverts to ABACUS (True=movable)."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+    atoms.set_constraint(FixScaled([1], mask=(True, True, False)))
+
+    move_list = atoms_to_move_list(atoms)
+
+    # ASE mask (True, True, False) = fix x,y → ABACUS (False, False, True)
+    np.testing.assert_array_equal(move_list[1], [False, False, True])
+
+
+# FixCartesian tests
+def test_fixcartesian_orthogonal():
+    """Test FixCartesian with orthogonal cell issues warning."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+    atoms.set_constraint(FixCartesian([1], mask=(True, False, True)))
+
+    with pytest.warns(UserWarning, match="FixCartesian"):
+        move_list = atoms_to_move_list(atoms)
+
+    np.testing.assert_array_equal(move_list[1], [False, True, False])
+
+
+def test_fixcartesian_nonorthogonal_raises():
+    """Test FixCartesian with non-orthogonal cell raises error."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[[5, 0, 0], [1, 5, 0], [0, 0, 5]])
+    atoms.set_constraint(FixCartesian([0], mask=(True, False, False)))
+
+    with pytest.raises(InputValidationError, match="non-orthogonal"):
+        atoms_to_move_list(atoms)
+
+
+# Multiple constraints
+def test_multiple_fixatoms():
+    """Test multiple FixAtoms constraints accumulate."""
+    atoms = Atoms("H4", positions=[[i, 0, 0] for i in range(4)])
+    atoms.set_constraint([FixAtoms(indices=[0]), FixAtoms(indices=[2, 3])])
+
+    move_list = atoms_to_move_list(atoms)
+
+    assert not np.any(move_list[0])  # Fixed
+    assert np.all(move_list[1])  # Free
+    assert not np.any(move_list[2])  # Fixed
+    assert not np.any(move_list[3])  # Fixed
+
+
+def test_mixed_fixatoms_and_fixscaled():
+    """Test FixAtoms + FixScaled combine correctly."""
+    atoms = Atoms("H4", positions=[[i, 0, 0] for i in range(4)], cell=[5, 5, 5])
+    atoms.set_constraint([FixAtoms(indices=[0]), FixScaled([1], mask=(False, True, False))])
+
+    move_list = atoms_to_move_list(atoms)
+
+    np.testing.assert_array_equal(move_list[0], [False, False, False])
+    np.testing.assert_array_equal(move_list[1], [True, False, True])
+    np.testing.assert_array_equal(move_list[2], [True, True, True])
+
+
+def test_overlapping_constraints():
+    """Test overlapping constraints use union of restrictions."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+    atoms.set_constraint(
+        [
+            FixScaled([1], mask=(True, False, False)),  # Fix x
+            FixScaled([1], mask=(False, True, False)),  # Fix y
+        ]
+    )
+
+    move_list = atoms_to_move_list(atoms)
+    np.testing.assert_array_equal(move_list[1], [False, False, True])  # x,y fixed
+
+
+# Error handling
+def test_unsupported_constraint_raises():
+    """Test unsupported constraint types raise error."""
+    atoms = Atoms("H2O", positions=[[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    atoms.set_constraint(FixBondLength(0, 1))
+
+    with pytest.raises(InputValidationError, match="Unsupported constraint"):
+        atoms_to_move_list(atoms)
+
+
+# Serialization tests
+def test_serialize_dynamics_with_constraints(aiida_profile_clean):
+    """Test serialize_dynamics converts constraints to Dict."""
+    atoms = Atoms("H3", positions=[[i, 0, 0] for i in range(3)])
+    atoms.set_constraint(FixAtoms(indices=[0]))
+
+    result = serialize_dynamics(atoms)
+
+    assert isinstance(result, orm.Dict)
+    assert result.get_dict()["m"] == [
+        [False, False, False],
+        [True, True, True],
+        [True, True, True],
+    ]
+
+
+def test_serialize_dynamics_no_constraints(aiida_profile_clean):
+    """Test serialize_dynamics returns None for unconstrained atoms."""
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]])
+    assert serialize_dynamics(atoms) is None
+
+
+def test_serialize_dynamics_dict_passthrough(aiida_profile_clean):
+    """Test serialize_dynamics passes through dict inputs."""
+    input_dict = {"m": [[True, True, True]]}
+    result = serialize_dynamics(input_dict)
+
+    assert isinstance(result, orm.Dict)
+    assert result.get_dict() == input_dict
+
+
+# Edge cases
+def test_single_atom():
+    """Test single atom structure."""
+    atoms = Atoms("H", positions=[[0, 0, 0]])
+    atoms.set_constraint(FixAtoms(indices=[0]))
+
+    move_list = atoms_to_move_list(atoms)
+    np.testing.assert_array_equal(move_list, [[False, False, False]])
+
+
+def test_large_structure():
+    """Test constraint on large structure."""
+    natoms = 100
+    atoms = Atoms("H" * natoms, positions=[[i, 0, 0] for i in range(natoms)])
+    atoms.set_constraint(FixAtoms(indices=list(range(0, natoms, 2))))
+
+    move_list = atoms_to_move_list(atoms)
+
+    assert move_list.shape == (natoms, 3)
+    assert not np.any(move_list[0::2])  # Even indices fixed
+    assert np.all(move_list[1::2])  # Odd indices free
+
+
+def test_empty_atoms():
+    """Test empty atoms object."""
+    assert atoms_to_move_list(Atoms()) is None
+
+
+# Integration test
+def test_boolean_to_abacus_format():
+    """Test boolean move_list converts to ABACUS 0/1 format."""
+    atoms = Atoms("H3", positions=[[i, 0, 0] for i in range(3)])
+    atoms.set_constraint(FixAtoms(indices=[1]))
+
+    move_list = atoms_to_move_list(atoms)
+    abacus_flags = move_list.astype(int)
+
+    expected = np.array([[1, 1, 1], [0, 0, 0], [1, 1, 1]])
+    np.testing.assert_array_equal(abacus_flags, expected)

--- a/tests/test_input_generation.py
+++ b/tests/test_input_generation.py
@@ -109,6 +109,172 @@ class TestInputFileGeneration:
         assert "ATOMIC_POSITIONS" in content
         assert "Cartesian" in content
 
+    def test_velocity_in_stru_file(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints, sandbox_folder
+    ):
+        """Test velocity values are written correctly to STRU file."""
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        num_atoms = len(si_structure.sites)
+        velocities = [[0.1, 0.0, 0.0]] * num_atoms
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": {}})
+        inputs.dynamics = orm.Dict({"v": velocities})
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+        process.prepare_for_submission(sandbox_folder)
+
+        stru_path = sandbox_folder.get_abs_path("STRU")
+        with open(stru_path, "r") as f:
+            content = f.read()
+
+        # Check velocity keyword appears
+        assert " v " in content
+        # Check velocity values
+        assert "0.1" in content
+
+        # Test using parameters port
+
+        num_atoms = len(si_structure.sites)
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": {"v": [[1.0, 1.0, 1.0]] * num_atoms}})
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+        process.prepare_for_submission(sandbox_folder)
+
+        stru_path = sandbox_folder.get_abs_path("STRU")
+        with open(stru_path, "r") as f:
+            content = f.read()
+
+        # Should contain parameters velocity
+        lines = [line for line in content.split("\n") if " v " in line]
+        assert len(lines) > 0
+        assert "1.0" in lines[0]
+
+    def test_velocity_validation_wrong_length(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints, sandbox_folder
+    ):
+        """Test error when velocity list length doesn't match atoms."""
+        from aiida.common import exceptions
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": {}})
+        inputs.dynamics = orm.Dict({"v": [[0.1, 0.0, 0.0]]})  # Only 1 velocity
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+
+        with pytest.raises(exceptions.InputValidationError, match="does not match number of atoms"):
+            process.prepare_for_submission(sandbox_folder)
+
+    def test_velocity_multiple_aliases(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints, sandbox_folder
+    ):
+        """Test error when multiple velocity aliases in dynamics port."""
+        from aiida.common import exceptions
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        num_atoms = len(si_structure.sites)
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": {}})
+        inputs.dynamics = orm.Dict({"v": [[0.1, 0.0, 0.0]] * num_atoms, "vel": [[0.2, 0.0, 0.0]] * num_atoms})
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+        with pytest.raises(exceptions.InputValidationError, match=r"Multiple velocity aliases.*dynamics"):
+            process.prepare_for_submission(sandbox_folder)
+
+        # In parameters
+        num_atoms = len(si_structure.sites)
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        v_list = [[0.1, 0.0, 0.0]] * num_atoms
+        vel_list = [[0.2, 0.0, 0.0]] * num_atoms
+        params_dict = {"input": {"basis_type": "pw"}, "stru": {"v": v_list, "velocity": vel_list}}
+        inputs.parameters = orm.Dict(params_dict)
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+        with pytest.raises(exceptions.InputValidationError, match=r"Multiple velocity aliases.*parameters"):
+            process.prepare_for_submission(sandbox_folder)
+
+    def test_magmom_multiple_aliases(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints, sandbox_folder
+    ):
+        """Test error when multiple magmom aliases in parameters."""
+        from aiida.common import exceptions
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        num_atoms = len(si_structure.sites)
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        stru_dict = {"mag": [[0.0, 0.0, 1.0]] * num_atoms, "magmom": [[0.0, 0.0, -1.0]] * num_atoms}
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": stru_dict})
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+        with pytest.raises(exceptions.InputValidationError, match="Multiple magmom aliases"):
+            process.prepare_for_submission(sandbox_folder)
+
+    def test_velocity_conflict_detection(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints, sandbox_folder
+    ):
+        """Test error when velocity specified in both dynamics and parameters."""
+        from aiida.common import exceptions
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        num_atoms = len(si_structure.sites)
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+        inputs.parameters = orm.Dict({"input": {"basis_type": "pw"}, "stru": {"v": [[0.1, 0.0, 0.0]] * num_atoms}})
+        inputs.dynamics = orm.Dict({"v": [[0.2, 0.0, 0.0]] * num_atoms})
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+
+        with pytest.raises(exceptions.InputValidationError, match="specified in both"):
+            process.prepare_for_submission(sandbox_folder)
+
     def test_pseudopotential_file_copying(self, calc_with_inputs, sandbox_folder):
         """Test that pseudopotential files are properly copied to calculation folder."""
         calcinfo = calc_with_inputs.prepare_for_submission(sandbox_folder)
@@ -201,7 +367,25 @@ class TestInputFileGeneration:
         with open(stru_path, "r") as f:
             content = f.read()
 
-        assert "magmom" in content
+        assert "magmom 0.0 0.0 1.0" in content
+
+        parameters = {
+            "input": {"basis_type": "pw", "ecutwfc": 50, "nspin": 2},
+            "stru": {
+                "mag": [[3.0]] * len(si_structure.sites),
+                "m": [[True, True, True]] * len(si_structure.sites),
+            },
+        }
+        inputs.parameters = orm.Dict(parameters)
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        calc = instantiate_process(runner, AbacusCalculation, **inputs)
+        calc.prepare_for_submission(sandbox_folder)
+
+        stru_path = sandbox_folder.get_abs_path("STRU")
+        with open(stru_path, "r") as f:
+            content = f.read()
+        assert "magmom 3.0" in content
 
     def test_restart_folder_handling(self, calc_with_inputs, sandbox_folder):
         """Test handling of restart_folder in calcinfo."""

--- a/tests/test_input_generation.py
+++ b/tests/test_input_generation.py
@@ -318,3 +318,122 @@ class TestInputFileGeneration:
         with open(stru_path, "r") as f:
             stru_content = f.read()
         assert "m 1 1 1" in stru_content
+
+    def test_dynamics_port_with_ase_constraints(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints
+    ):
+        """Test that ASE constraints via dynamics port are correctly converted to STRU 'm' flags."""
+        from aiida_abacus.utils import serialize_dynamics
+        from ase import Atoms
+        from ase.constraints import FixAtoms
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+
+        # Basic parameters WITHOUT 'm' flags
+        parameters = {
+            "input": {
+                "basis_type": "pw",
+                "ecutwfc": 60,
+                "scf_thr": 1e-7,
+                "calculation": "scf",
+            },
+            "stru": {},  # No 'm' here - will come from dynamics
+        }
+        inputs.parameters = orm.Dict(parameters)
+
+        # Create ASE Atoms with constraints - fix first atom
+        positions = [site.position for site in si_structure.sites]
+        symbols = [site.kind_name for site in si_structure.sites]
+        cell = si_structure.cell
+        atoms = Atoms(symbols=symbols, positions=positions, cell=cell)
+        atoms.set_constraint(FixAtoms(indices=[0]))
+
+        # Use dynamics port with ASE Atoms
+        inputs.dynamics = serialize_dynamics(atoms)
+
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        # Instantiate process
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+
+        # Generate STRU content
+        stru_content, _ = process.generate_structure(si_structure, inputs.pseudos, {})  # Empty stru parameters
+
+        # Verify STRU contains correct 'm' flags
+        # First atom should be "m 0 0 0" (fixed)
+        # Second atom should be "m 1 1 1" (movable)
+        assert "m 0 0 0" in stru_content  # First atom fixed
+        assert "m 1 1 1" in stru_content  # Second atom movable
+
+    def test_dynamics_port_conflicts_with_parameters_raises_error(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints
+    ):
+        """Test that specifying 'm' in both dynamics and parameters raises an error."""
+        from aiida.common.exceptions import InputValidationError
+
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+
+        # Parameters with 'm' specified
+        num_sites = len(si_structure.sites)
+        parameters = {
+            "input": {"basis_type": "pw", "ecutwfc": 60, "calculation": "scf"},
+            "stru": {"m": [[True, True, True]] * num_sites},
+        }
+        inputs.parameters = orm.Dict(parameters)
+
+        # Dynamics port also has 'm' - this should raise an error
+        inputs.dynamics = orm.Dict({"m": [[False, False, False]] + [[True, True, True]] * (num_sites - 1)})
+
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+
+        # Should raise InputValidationError when both sources provide 'm'
+        with pytest.raises(InputValidationError, match="both 'dynamics' port and parameters"):
+            process.generate_structure(si_structure, inputs.pseudos, parameters["stru"])
+
+    def test_legacy_parameters_still_works(
+        self, aiida_profile_clean, abacus_code, si_structure, pseudo_familty, abacus_kpoints
+    ):
+        """Test that legacy parameters['stru']['m'] approach still works (backwards compatibility)."""
+        manager = get_manager()
+        runner = manager.get_runner()
+
+        inputs = AttributeDict()
+        inputs.code = abacus_code
+        inputs.structure = si_structure
+        inputs.pseudos = pseudo_familty.get_pseudos(structure=si_structure)
+        inputs.kpoints = abacus_kpoints
+
+        # Legacy approach: specify 'm' in parameters
+        num_sites = len(si_structure.sites)
+        parameters = {
+            "input": {"basis_type": "pw", "ecutwfc": 60, "calculation": "scf"},
+            "stru": {"m": [[False, False, False]] + [[True, True, True]] * (num_sites - 1)},  # First atom fixed
+        }
+        inputs.parameters = orm.Dict(parameters)
+        # NO dynamics port provided
+
+        inputs.metadata = AttributeDict({"options": {"resources": {"num_machines": 1, "num_mpiprocs_per_machine": 1}}})
+
+        process = instantiate_process(runner, AbacusCalculation, **inputs)
+
+        stru_content, _ = process.generate_structure(si_structure, inputs.pseudos, parameters["stru"])
+
+        # First atom should be fixed (from legacy parameters)
+        assert "m 0 0 0" in stru_content
+        assert "m 1 1 1" in stru_content


### PR DESCRIPTION
## Summary

Implements ASE constraints integration for ABACUS selective dynamics, enabling automatic conversion of ASE constraint objects (FixAtoms, FixScaled, FixCartesian) to ABACUS STRU file 'm' flags.

This follows the same architecture as aiida-vasp PR #837.

## Key Features

- **Three constraint types supported:**
  - `FixAtoms` - Fixes all 3 directions for specified atoms
  - `FixScaled` - Fixes specific fractional coordinate directions
  - `FixCartesian` - Fixes Cartesian directions (requires orthogonal cells)

- **Three methods to specify selective dynamics** (fully backwards compatible):
  1. ASE Atoms via `dynamics` port (NEW, recommended)
  2. Manual Dict via `dynamics` port (NEW)
  3. Legacy `parameters['stru']['m']` (EXISTING)

- **Validation:** Raises error if 'm' flags specified in both dynamics and parameters to prevent ambiguity

## Changes

### Core Implementation
- `src/aiida_abacus/utils.py` - Added `serialize_dynamics()` function, fixed docstrings
- `src/aiida_abacus/calculations.py` - Enabled dynamics port with automatic conversion and conflict validation

### Tests
- `tests/test_constraints.py` - 17 comprehensive unit tests (simplified from 23)
- `tests/test_input_generation.py` - 3 integration tests including conflict validation

### Documentation
- `examples/example_with_constraints.py` - Working examples with detailed comments
- `docs/source/howto/calculations.md` - Complete user guide with troubleshooting

## Test Results

✅ All 17 constraint unit tests pass
✅ All 3 integration tests pass  
✅ 179 total tests pass (zero regressions)
✅ Full backwards compatibility maintained

## Usage Example

```python
from ase.build import bulk
from ase.constraints import FixAtoms

# Create structure with constraints
atoms = bulk('Si', 'diamond', a=5.43).repeat((2, 2, 2))
atoms.set_constraint(FixAtoms(indices=[0, 1, 2, 3]))

# Use with builder - constraints automatically converted!
builder.structure = StructureData(ase=atoms)
builder.dynamics = atoms
```
