### PR TITLE
Fix/band exit codes

### DIFF
--- a/src/aiida_abacus/calculations.py
+++ b/src/aiida_abacus/calculations.py
@@ -192,6 +192,22 @@ class AbacusCalculation(CalcJob):
             "ERROR_CALCULATION_INCOMPLETE",
             message="Calculation did not complete successfully - 'Total Time' not found at end of running log.",
         )
+        spec.exit_code(
+            410,
+            "ERROR_SCF_NOT_CONVERGED",
+            message="SCF calculation did not converge within the specified electronic minimization steps.",
+        )
+        spec.exit_code(
+            500,
+            "ERROR_IONIC_NOT_CONVERGED",
+            message="Ionic minimization did not converge within the specified iterations.",
+        )
+        spec.exit_code(
+            501,
+            "ERROR_IONIC_CONVERGED_BUT_SCF_FAILED",
+            message="Ionic minimization converged but final SCF calculation did not converge.",
+        )
+
         # Set 'misc' to be default output node so calcjob.res and verdi calcjob res works
         spec.default_output_node = "misc"
 

--- a/src/aiida_abacus/parsers/abacus.py
+++ b/src/aiida_abacus/parsers/abacus.py
@@ -135,6 +135,42 @@ class AbacusParser(Parser):
         # Define the output nodes
         self.out("misc", misc_node)
 
+        # Check convergence status and return appropriate exit code (after all parsing is done)
+        return self._check_convergence(run_status, run_type)
+
+    def _check_convergence(self, run_status, run_type):
+        """
+        Check convergence status based on run_type.
+
+        :param run_status: The run_status dictionary from parsing
+        :param run_type: The calculation type (scf, relax, cell-relax, md)
+        :return: An exit code if there are issues, None if converged or not applicable
+        """
+        scf_converged = run_status.get("scf_converged")
+        opt_converged = run_status.get("opt_converged")
+
+        # SCF calculation
+        if run_type == "scf":
+            if not scf_converged:
+                self.logger.error("SCF calculation did not converge")
+                return self.exit_codes.ERROR_SCF_NOT_CONVERGED
+            return None
+
+        # Relax/MD calculation
+        elif run_type in ["relax", "cell-relax", "md"]:
+            # Ionic converged but final SCF failed
+            if opt_converged and not scf_converged:
+                self.logger.error("Ionic minimization converged but final SCF did not converge")
+                return self.exit_codes.ERROR_IONIC_CONVERGED_BUT_SCF_FAILED
+
+            # Ionic not converged
+            if not opt_converged:
+                self.logger.error("Ionic minimization did not converge")
+                return self.exit_codes.ERROR_IONIC_NOT_CONVERGED
+            return None
+
+        return None
+
     def check_include_node(self, name: str):
         """
         Check whether to include certain output node

--- a/src/aiida_abacus/parsers/raw_parsers.py
+++ b/src/aiida_abacus/parsers/raw_parsers.py
@@ -90,8 +90,7 @@ class AbacusRawParser(BaseRawParser):
                 self.results["number_of_bands"] = int(line.strip().split()[-1])
             elif "EFERMI" in line:
                 self.results["fermi_level"] = float(line.strip().split()[-2])
-
-        # Check calculation completion status
+        # Check calculation completion and convergence status
         self.results["run_status"] = self.compose_run_status()
 
         self.is_parsed = True
@@ -178,43 +177,83 @@ class AbacusRawParser(BaseRawParser):
 
     def compose_run_status(self) -> dict:
         """
-        Check if the calculation completed successfully by looking for 'Total  Time'
-        at the end of the running log file and compose the run status dictionary.
+        Check calculation completion and convergence status by scanning from the end of the log file.
+        Returns both run completion status and SCF/OPT convergence information.
 
-        :returns: Dictionary with completion status information
+        :returns: Dictionary with completion status, SCF convergence, and OPT convergence
         """
-        run_status = {"completed": False, "completion_marker_found": False, "termination_marker": None}
+        # Initialize run status
+        run_status = {
+            "completed": False, 
+            "completion_marker_found": False, 
+            "termination_marker": None,
+            "scf_converged": "unknown",
+            "opt_converged": "unknown"
+        }
 
         try:
             # Check if we have any lines to analyze
             if not self.lines:
-                logger.warning("Empty file content provided for completion check")
+                logger.warning("Empty file content provided for status check")
+                run_status["scf_converged"] = "error"
+                run_status["opt_converged"] = "error"
                 return run_status
 
-            # Get the last few lines to check for completion markers
-            last_lines = self.lines[-10:] if len(self.lines) >= 10 else self.lines
+            # Scan from the end of the log file
+            scf_done = False
+            opt_done = False
+            completion_found = False
 
-            # Check for ABACUS completion marker
-            completion_marker = "Total  Time"  # ABACUS standard completion marker
-
-            # Check for completion marker in the last lines
-            for line in reversed(last_lines):
+            for line in reversed(self.lines):
                 line_stripped = line.strip()
 
-                # Check for successful completion marker
-                if completion_marker in line_stripped:
+                # Check for ABACUS completion marker
+                if not completion_found and "Total  Time" in line_stripped:
                     run_status["completed"] = True
                     run_status["completion_marker_found"] = True
-                    run_status["termination_marker"] = completion_marker
-                    logger.info(f"Found completion marker '{completion_marker}' in line: {line_stripped}")
+                    run_status["termination_marker"] = "Total  Time"
+                    logger.info(f"Found completion marker 'Total  Time' in line: {line_stripped}")
+                    completion_found = True
+
+                # Check OPT/ionic convergence status
+                if not opt_done:
+                    if 'Relaxation is converged!' in line or 'ionic relaxation is converged' in line:
+                        run_status["opt_converged"] = "converged"
+                        opt_done = True
+                        logger.debug(f"OPT converged found in: {line_stripped}")
+                    elif ('not converged' in line.lower() and 'ionic' in line.lower()) or \
+                         'Lattice relaxation is not converged yet!' in line:
+                        run_status["opt_converged"] = "not_converged"
+                        opt_done = True
+                        logger.debug(f"OPT not converged found in: {line_stripped}")
+
+                # Check SCF/electronic convergence status
+                if not scf_done:
+                    if 'charge density convergence is achieved' in line or '#SCF IS CONVERGED#' in line:
+                        run_status["scf_converged"] = "converged"
+                        scf_done = True
+                        logger.debug(f"SCF converged found in: {line_stripped}")
+                    elif 'convergence has not been achieved' in line or 'SCF IS NOT CONVERGED' in line:
+                        run_status["scf_converged"] = "not_converged"
+                        scf_done = True
+                        logger.debug(f"SCF not converged found in: {line_stripped}")
+
+                # Return as soon as either SCF or OPT is determined
+                if scf_done or opt_done:
+                    if not completion_found:
+                        logger.warning("Completion marker 'Total  Time' not found in log file")
                     return run_status
 
-            # If no completion marker found, calculation is incomplete
-            logger.warning(f"Completion marker '{completion_marker}' not found in log file")
+            # Log if no convergence info found
+            if not scf_done:
+                logger.debug("No SCF convergence information found in log")
+            if not opt_done:
+                logger.debug("No OPT convergence information found in log")
 
         except Exception as e:
-            logger.error(f"Error checking calculation completion: {e!s}")
-            run_status["completed"] = False
+            logger.error(f"Error checking calculation status: {e!s}")
+            run_status["scf_converged"] = "error"
+            run_status["opt_converged"] = "error"
             run_status["termination_marker"] = f"error: {e!s}"
 
         return run_status

--- a/src/aiida_abacus/parsers/raw_parsers.py
+++ b/src/aiida_abacus/parsers/raw_parsers.py
@@ -182,24 +182,22 @@ class AbacusRawParser(BaseRawParser):
 
         :returns: Dictionary with completion status, SCF convergence, and OPT convergence
         """
-        # Initialize run status
         run_status = {
-            "completed": False, 
-            "completion_marker_found": False, 
+            "completed": False,
+            "completion_marker_found": False,
             "termination_marker": None,
-            "scf_converged": "unknown",
-            "opt_converged": "unknown"
+            "scf_converged": None,
+            "opt_converged": None,
         }
 
         try:
-            # Check if we have any lines to analyze
             if not self.lines:
                 logger.warning("Empty file content provided for status check")
-                run_status["scf_converged"] = "error"
-                run_status["opt_converged"] = "error"
+                run_status["scf_converged"] = False
+                run_status["opt_converged"] = False
+                run_status["termination_marker"] = "empty file"
                 return run_status
 
-            # Scan from the end of the log file
             scf_done = False
             opt_done = False
             completion_found = False
@@ -217,43 +215,41 @@ class AbacusRawParser(BaseRawParser):
 
                 # Check OPT/ionic convergence status
                 if not opt_done:
-                    if 'Relaxation is converged!' in line or 'ionic relaxation is converged' in line:
-                        run_status["opt_converged"] = "converged"
+                    if "Relaxation is converged!" in line or "ionic relaxation is converged" in line:
+                        run_status["opt_converged"] = True
                         opt_done = True
                         logger.debug(f"OPT converged found in: {line_stripped}")
-                    elif ('not converged' in line.lower() and 'ionic' in line.lower()) or \
-                         'Lattice relaxation is not converged yet!' in line:
-                        run_status["opt_converged"] = "not_converged"
+                    elif (
+                        "not converged" in line.lower() and "ionic" in line.lower()
+                    ) or "Lattice relaxation is not converged yet" in line:
+                        run_status["opt_converged"] = False
                         opt_done = True
                         logger.debug(f"OPT not converged found in: {line_stripped}")
 
                 # Check SCF/electronic convergence status
                 if not scf_done:
-                    if 'charge density convergence is achieved' in line or '#SCF IS CONVERGED#' in line:
-                        run_status["scf_converged"] = "converged"
+                    if "charge density convergence is achieved" in line or "#SCF IS CONVERGED#" in line:
+                        run_status["scf_converged"] = True
                         scf_done = True
                         logger.debug(f"SCF converged found in: {line_stripped}")
-                    elif 'convergence has not been achieved' in line or 'SCF IS NOT CONVERGED' in line:
-                        run_status["scf_converged"] = "not_converged"
+                    elif "convergence has not been achieved" in line or "SCF IS NOT CONVERGED" in line:
+                        run_status["scf_converged"] = False
                         scf_done = True
                         logger.debug(f"SCF not converged found in: {line_stripped}")
 
-                # Return as soon as either SCF or OPT is determined
-                if scf_done or opt_done:
-                    if not completion_found:
-                        logger.warning("Completion marker 'Total  Time' not found in log file")
+                # Return as soon as both SCF and OPT convergence is determined
+                if scf_done and opt_done:
                     return run_status
-
-            # Log if no convergence info found
-            if not scf_done:
-                logger.debug("No SCF convergence information found in log")
-            if not opt_done:
-                logger.debug("No OPT convergence information found in log")
+            if scf_done or opt_done:
+                return run_status
+            else:
+                # Error if both are still None after scanning entire file
+                logger.error("Convergence status not found in log file")
 
         except Exception as e:
             logger.error(f"Error checking calculation status: {e!s}")
-            run_status["scf_converged"] = "error"
-            run_status["opt_converged"] = "error"
+            run_status["scf_converged"] = False
+            run_status["opt_converged"] = False
             run_status["termination_marker"] = f"error: {e!s}"
 
         return run_status

--- a/src/aiida_abacus/workflows/band.py
+++ b/src/aiida_abacus/workflows/band.py
@@ -71,6 +71,10 @@ class AbacusBandWorkChain(ProtocolMixin, WorkChain):
             cls.run_bands_dos,
             cls.verify_bands_dos,
         )
+        spec.exit_code(401, "ERROR_RELAX_PROCESS_FAILED", message="The relax process failed.")
+        spec.exit_code(402, "ERROR_SCF_PROCESS_FAILED", message="The SCF process failed.")
+        spec.exit_code(403, "ERROR_SUB_PROC_BANDS_FAILED", message="The bands subprocess failed.")
+        spec.exit_code(404, "ERROR_SUB_PROC_DOS_FAILED", message="The DOS subprocess failed.")
         spec.output("band_structure", valid_type=orm.BandsData, help="Output band structure data.")
         spec.output(
             "primitive_structure",

--- a/src/aiida_abacus/workflows/base.py
+++ b/src/aiida_abacus/workflows/base.py
@@ -9,8 +9,9 @@ from aiida import orm
 from aiida.common import AttributeDict, exceptions
 from aiida.common.exceptions import NotExistent
 from aiida.common.lang import type_check
-from aiida.engine import calcfunction, while_
+from aiida.engine import calcfunction, process_handler, while_
 from aiida.engine.processes.workchains.restart import BaseRestartWorkChain
+from aiida.engine.processes.workchains.utils import ProcessHandlerReport
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import GroupFactory
 from aiida_pseudo.groups.family import PseudoPotentialFamily
@@ -131,6 +132,11 @@ class AbacusBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message="The electronic minimization cycle did not reach self-consistency, but `scf_must_converge` "
             "is `False` and/or `electron_maxstep` is 0.",
         )
+        spec.exit_code(
+            500,
+            "ERROR_SUBPROCESS_FAILED",
+            message="Subprocess failed due to convergence issues.",
+        )
 
     def validate_kpoints(self):
         """Validate the inputs related to k-points.
@@ -166,6 +172,28 @@ class AbacusBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report("{}<{}> failed with exit status {}: {}".format(*arguments))
         self.report(f"Action taken: {action}")
+
+    @process_handler(priority=500)
+    def handle_convergence_errors(self, calculation):
+        """Handle convergence-related errors from subprocess calculation."""
+        exit_status = calculation.exit_status
+
+        # Get exit codes from the subprocess calculation
+        calc_exit_codes = calculation.process_class.exit_codes
+
+        if exit_status == calc_exit_codes.ERROR_SCF_NOT_CONVERGED.status:
+            self.report_error_handled(calculation, "SCF calculation did not converge")
+            return ProcessHandlerReport(do_break=True, exit_code=self.exit_codes.ERROR_SUBPROCESS_FAILED)
+
+        if exit_status == calc_exit_codes.ERROR_IONIC_NOT_CONVERGED.status:
+            self.report_error_handled(calculation, "Ionic minimization did not converge")
+            return ProcessHandlerReport(do_break=True, exit_code=self.exit_codes.ERROR_SUBPROCESS_FAILED)
+
+        if exit_status == calc_exit_codes.ERROR_IONIC_CONVERGED_BUT_SCF_FAILED.status:
+            self.report_error_handled(calculation, "Ionic minimization converged but final SCF failed")
+            return ProcessHandlerReport(do_break=True, exit_code=self.exit_codes.ERROR_SUBPROCESS_FAILED)
+
+        return None
 
     def setup(self):
         """Call the ``setup`` of the ``BaseRestartWorkChain`` and create the inputs dictionary in ``self.ctx.inputs``.


### PR DESCRIPTION
## Description

This PR adds four missing exit code definitions in the `AbacusBandWorkChain.define()` method that were being used but not defined:

- `ERROR_RELAX_PROCESS_FAILED` (401) - Used in `verify_relax()`
- `ERROR_SCF_PROCESS_FAILED` (402) - Used in `verify_scf()`
- `ERROR_SUB_PROC_BANDS_FAILED` (403) - Used in `verify_bands_dos()`
- `ERROR_SUB_PROC_DOS_FAILED` (404) - Used in `verify_bands_dos()`

## Problem

These exit codes were referenced in the verify methods but were not defined in the process spec, which would cause runtime errors when the workchain tries to return these exit codes.

## Testing

The fix ensures that when any of these error conditions are encountered, the workchain can properly return the appropriate exit code without raising an AttributeError.