### PR TITLE
fix(parser): detect cell-relax non-convergence and suppress glob pattern of STRU_ION*_D 

### DIFF
--- a/src/aiida_abacus/parsers/abacus.py
+++ b/src/aiida_abacus/parsers/abacus.py
@@ -78,6 +78,9 @@ class AbacusParser(Parser):
         # Check if the files are retrieved
         missing = []
         for name in expected_files:
+            # Skip glob patterns — they cannot be looked up by exact name via get_object
+            if any(c in name for c in "*?["):
+                continue
             try:
                 output_folder.get_object(name)
             except FileNotFoundError:

--- a/src/aiida_abacus/parsers/raw_parsers.py
+++ b/src/aiida_abacus/parsers/raw_parsers.py
@@ -246,7 +246,7 @@ class AbacusRawParser(BaseRawParser):
         - SCF convergence:
           current branches: "!!SCF IS NOT CONVERGED!!" / "#SCF IS CONVERGED#"
           LTS branches: "!! convergence has not been achieved @_@" / "charge density convergence is achieved"
-        - Ionic convergence: "Relaxation is (not) converged"
+        - Ionic convergence: "Relaxation is (not) converged" / "Lattice relaxation is not converged yet"
         - Geometry convergence: "Geometry relaxation is not converged"
         - Mixed state: "Relaxation is converged, but the SCF is unconverged"
 
@@ -261,7 +261,7 @@ class AbacusRawParser(BaseRawParser):
         patterns = {
             "scf_not_converged": re.compile(r"!!SCF IS NOT CONVERGED!!|!!\s*convergence has not been achieved\s*@_@"),
             "scf_converged": re.compile(r"#SCF IS CONVERGED#|charge density convergence is achieved"),
-            "ionic_not_converged": re.compile(r"Relaxation is not converged"),
+            "ionic_not_converged": re.compile(r"(?:Lattice )?[Rr]elaxation is not converged(?: yet)?"),
             "ionic_converged": re.compile(r"Relaxation is converged!"),
             "geometry_not_converged": re.compile(r"Geometry relaxation is not converged"),
             "relax_scf_not_converged": re.compile(r"Relaxation is converged, but the SCF is unconverged"),

--- a/src/aiida_abacus/parsers/raw_parsers.py
+++ b/src/aiida_abacus/parsers/raw_parsers.py
@@ -262,7 +262,7 @@ class AbacusRawParser(BaseRawParser):
             "scf_not_converged": re.compile(r"!!SCF IS NOT CONVERGED!!|!!\s*convergence has not been achieved\s*@_@"),
             "scf_converged": re.compile(r"#SCF IS CONVERGED#|charge density convergence is achieved"),
             "ionic_not_converged": re.compile(r"(?:Lattice )?[Rr]elaxation is not converged(?: yet)?"),
-            "ionic_converged": re.compile(r"Relaxation is converged!"),
+            "ionic_converged": re.compile(r"(?:Lattice )?[Rr]elaxation is converged!"),
             "geometry_not_converged": re.compile(r"Geometry relaxation is not converged"),
             "relax_scf_not_converged": re.compile(r"Relaxation is converged, but the SCF is unconverged"),
         }


### PR DESCRIPTION
Detect "Lattice relaxation is not converged yet" (cell-relax) in addition to the existing "Relaxation is not converged" (relax) pattern, so that cell-relax calculations reaching maximium ionic steps properly emit exit code 303, for different ABACUS versions return different messages.

Also skip glob patterns (e.g. STRU_ION*_D) in the missing-files check, since get_object() does exact name matching and glob entries always appear missing.