### PR TITLE
feat(parser): parse Total Time into misc as seconds

### DIFF
--- a/src/aiida_abacus/parsers/raw_parsers.py
+++ b/src/aiida_abacus/parsers/raw_parsers.py
@@ -142,6 +142,37 @@ class AbacusRawParser(BaseRawParser):
         self.results["magnetism"] = magnetism
         self.results["final_magnetism"] = final_magnetism
 
+    def parse_total_time(self) -> None:
+        """
+        Parse the ``Total  Time`` wall-clock duration reported at the end of the
+        ABACUS log, e.g.::
+
+            Total  Time  : 0 h 0 mins 2 secs
+
+        The result is stored in ``self.results`` as ``total_time`` (a float of
+        seconds) and ``total_time_unit`` (the string ``"s"``). When the line
+        cannot be located or fails to parse, both keys are set to ``None`` so
+        the caller can distinguish "not reported" from "reported as zero".
+        """
+        total_time = None
+        # The "Total  Time" line uses two spaces between "Total" and "Time";
+        # mirror that exactly in the pattern. The summary line is always at
+        # the very end of the log, so we only need to scan the tail and pick
+        # the first match we find there; this avoids a full-log regex sweep
+        # for very large log files.
+        total_time_re = re.compile(r"Total\s+Time\s*:\s*(\d+)\s*h\s*(\d+)\s*mins\s*(\d+)\s*secs")
+        for line in self.lines[-100:]:
+            match = total_time_re.search(line)
+            if match:
+                hours = int(match.group(1))
+                minutes = int(match.group(2))
+                seconds = int(match.group(3))
+                total_time = float(hours * 3600 + minutes * 60 + seconds)
+                break
+
+        self.results["total_time"] = total_time
+        self.results["total_time_unit"] = "s" if total_time is not None else None
+
     def parse(self) -> dict:
         """
         Parse ABACUS output file.
@@ -150,6 +181,7 @@ class AbacusRawParser(BaseRawParser):
         """
         self.parse_blocks()
         self.parse_magnetism()
+        self.parse_total_time()
         # Parse the lines one-by-one for general information of the calculation
         self.results["energies"] = []  # Container for the per-ionic-step energies in eV
         self.results["electronic_energies"] = []

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -652,3 +652,16 @@ def test_parser_omits_magnetism_when_nspin_is_unset(calc_with_retrieved, tmp_pat
     misc = parser.outputs["misc"].get_dict()
     assert "magnetism" not in misc
     assert "final_magnetism" not in misc
+
+
+def test_parser_exposes_total_time_in_seconds(parser_with_retrieved):
+    """The `Total  Time` line in `running_*.log` should land in `misc` as seconds.
+
+    The pw_Si2 fixture (lines 683-685) reports `0 h 0 mins 2 secs`, so the
+    parsed value is 2 seconds and the unit is `s`.
+    """
+    parser, _ = parser_with_retrieved("pw_Si2")
+    misc = parser.outputs["misc"].get_dict()
+
+    assert misc["total_time"] == 2.0
+    assert misc["total_time_unit"] == "s"

--- a/tests/test_raw_parser.py
+++ b/tests/test_raw_parser.py
@@ -320,3 +320,79 @@ def test_parse_magnetism_on_nspin4_noncollinear_log(data_folder):
     # First nspin=4 step has a clearly non-zero mz component.
     assert magnetism["total_magnetism"][0][2] == pytest.approx(0.212635)
     assert magnetism["absolute_magnetism"][0] == pytest.approx(0.212659)
+
+
+def test_parse_total_time_returns_none_when_no_total_time_line():
+    parser = AbacusRawParser(
+        StringIO(
+            "\n".join(
+                [
+                    " some unrelated log line",
+                    " E_KohnSham     -1989.2618545111     -27065.2960353985",
+                ]
+            )
+        )
+    )
+
+    parser.parse_total_time()
+
+    assert parser.results["total_time"] is None
+    assert parser.results["total_time_unit"] is None
+
+
+def test_parse_total_time_converts_to_seconds():
+    parser = AbacusRawParser(
+        StringIO(
+            "\n".join(
+                [
+                    " Start  Time  : Sat Mar 22 15:22:30 2025",
+                    " Finish Time  : Sat Mar 22 15:22:32 2025",
+                    " Total  Time  : 0 h 0 mins 2 secs ",
+                ]
+            )
+        )
+    )
+
+    parser.parse_total_time()
+
+    assert parser.results["total_time"] == 2.0
+    assert parser.results["total_time_unit"] == "s"
+
+
+def test_parse_total_time_handles_hours_and_minutes():
+    parser = AbacusRawParser(StringIO("Total  Time  : 1 h 2 mins 3 secs \n"))
+
+    parser.parse_total_time()
+
+    # 1*3600 + 2*60 + 3 = 3723
+    assert parser.results["total_time"] == 3723.0
+    assert parser.results["total_time_unit"] == "s"
+
+
+def test_parse_total_time_picks_first_match_in_tail_window():
+    parser = AbacusRawParser(
+        StringIO(
+            "\n".join(
+                [
+                    " ...intermediate log lines...",
+                    " Total  Time  : 0 h 0 mins 1 secs ",
+                    " Total  Time  : 0 h 0 mins 27 secs ",
+                ]
+            )
+        )
+    )
+
+    parser.parse_total_time()
+
+    # The parser only scans the last 100 lines and returns the first match
+    # it finds there; the second occurrence is irrelevant.
+    assert parser.results["total_time"] == 1.0
+
+
+def test_parse_total_time_on_pw_si2_log(data_folder):
+    """The pw_Si2 fixture (lines 683-685) reports `0 h 0 mins 2 secs` -> 2 s."""
+    parser = AbacusRawParser(data_folder / "pw_Si2/OUT.aiida/running_scf.log")
+    parser.parse_total_time()
+
+    assert parser.results["total_time"] == 2.0
+    assert parser.results["total_time_unit"] == "s"


### PR DESCRIPTION
ABACUS ends the running log with a wall-clock summary line, e.g.:

    Total  Time  : 0 h 0 mins 2 secs

Add a dedicated parser that converts this into a float of seconds and exposes it in the misc output as ``total_time`` together with the unit ``total_time_unit == "s"``. The line uses two spaces between "Total" and "Time"; the pattern matches it exactly and falls back to ``None`` for both keys when the line is absent, so callers can distinguish "not reported" from "reported as zero". When multiple lines are present in the log the last one wins.

Tests: 4 raw-parser unit tests (synthetic inputs covering seconds-only, hours+minutes+seconds, repeated occurrences, missing-line) plus 1 integration test against the pw_Si2 fixture, which reports `0 h 0 mins 2 secs` at lines 683-685.