### PR TITLE
feat(parser): record fermi level on the DOS output node

### DIFF
--- a/src/aiida_abacus/parsers/abacus.py
+++ b/src/aiida_abacus/parsers/abacus.py
@@ -234,6 +234,9 @@ class AbacusParser(Parser):
                     dos_node.set_array("dos1", result["dos1"])
                 if result["dos2"] is not None:
                     dos_node.set_array("dos2", result["dos2"])
+                fermi_level = misc_results.get("fermi_level")
+                if fermi_level is not None:
+                    dos_node.base.attributes.set("fermi_level", fermi_level)
                 self.out("dos", dos_node)
 
         # TODO: there could be other types that should have a output structure

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -638,6 +638,29 @@ def test_parser_omits_magnetism_when_nspin_is_1(calc_with_retrieved, tmp_path, d
     assert "final_magnetism" not in misc
 
 
+def test_parser_dos_records_fermi_level_from_running_log(calc_with_retrieved, tmp_path, data_folder):
+    """`EFERMI` from `running_*.log` lands on the dos ArrayData as an attribute."""
+    file_path = tmp_path / "pw_si2_dos"
+    _write_retrieved_tree(
+        file_path,
+        "scf",
+        (data_folder / "pw_Si2" / "OUT.aiida" / "running_scf.log").read_text(),
+        warning_content=(data_folder / "pw_Si2" / "OUT.aiida" / "warning.log").read_text(),
+    )
+    (file_path / "OUT.aiida" / "DOS1_smearing.dat").write_text(
+        "\n".join(f"{e:.6f} {d:.6f}" for e, d in zip([-4.0, -2.0, 0.0, 2.0, 4.0], [0.1, 0.4, 1.0, 0.4, 0.1]))
+    )
+
+    node = calc_with_retrieved(
+        str(file_path),
+        parameters={"input": {"calculation": "scf"}},
+        settings={"include_dos": True},
+    )
+    parser = AbacusParser(node)
+    assert parser.parse() is None
+    assert parser.outputs["dos"].base.attributes.get("fermi_level") == 6.5508038645
+
+
 def test_parser_omits_magnetism_when_nspin_is_unset(calc_with_retrieved, tmp_path, data_folder):
     """A calculation that omits ``nspin`` should default to nspin=1 and skip magnetism."""
     source_log = (data_folder / "mag_Si_lcao/nspin2_running_scf.log").read_text()


### PR DESCRIPTION
The bands branch already attaches `fermi_level` (parsed from the `EFERMI = <value> <unit>` line in `running_*.log`) to the BandsData node as a base attribute. The DOS branch was missing this, so callers that plot the DOS could not align it with the fermi level from the sibling bands output.

Mirror the bands convention in the DOS branch: read the fermi level already stored in `misc_results["fermi_level"]` and, when present, attach it to the dos ArrayData as `base.attributes["fermi_level"]`. When the running log does not contain an `EFERMI` line the DOS node is produced unchanged.

Tests: one new integration case in `tests/test_parser.py`, `test_parser_dos_records_fermi_level_from_running_log`, which stages the pw_Si2 fixture (reporting `EFERMI = 6.5508038645 eV`) plus a synthetic DOS1 file and asserts the DOS node carries the same value. The omission path is covered by the `if fermi_level is not None` guard itself.